### PR TITLE
LaravelUppyCompanion: allow serialized closures to be assigned by e.g. `artisan route:cache`

### DIFF
--- a/src/LaravelUppyCompanion.php
+++ b/src/LaravelUppyCompanion.php
@@ -3,36 +3,38 @@
 namespace STS\LaravelUppyCompanion;
 
 use Aws\S3\S3ClientInterface;
+use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
+use Laravel\SerializableClosure\Contracts\Serializable as SerializableClosure;
 
 class LaravelUppyCompanion
 {
-    private \Closure $clientCallback;
+    private Closure|SerializableClosure $clientCallback;
     private S3ClientInterface $client;
 
-    private \Closure $bucketCallback;
+    private Closure|SerializableClosure $bucketCallback;
     private string $bucket;
 
-    private ?\Closure $keyCallback;
+    private Closure|SerializableClosure|null $keyCallback;
 
-    public function __construct(\Closure|string|null $bucket = null, \Closure|S3ClientInterface|null $client = null, ?\Closure $key = null)
+    public function __construct(Closure|string|null $bucket = null, Closure|S3ClientInterface|null $client = null, ?Closure $key = null)
     {
         if ($bucket && $client) {
             $this->configure($bucket, $client, $key);
         }
     }
 
-    public function configure(\Closure|string $bucket, \Closure|S3ClientInterface $client, ?\Closure $key = null)
+    public function configure(Closure|string $bucket, Closure|S3ClientInterface $client, ?Closure $key = null)
     {
-        if ($bucket instanceof \Closure) {
+        if ($bucket instanceof Closure) {
             $this->bucketCallback = $bucket;
         } else {
             $this->bucket = $bucket;
         }
 
-        if ($client instanceof \Closure) {
+        if ($client instanceof Closure) {
             $this->clientCallback = $client;
         } else {
             $this->client = $client;


### PR DESCRIPTION
When running the `route:cache` command I see the following error:

```
$ sail artisan route:cache

   TypeError

  Cannot assign Laravel\SerializableClosure\Serializers\Native to property STS\LaravelUppyCompanion\LaravelUppyCompanion::$keyCallback of type ?Closure

  at vendor/laravel/serializable-closure/src/Serializers/Native.php:513
    509▕                     if (is_array($value) || is_object($value)) {
    510▕                         $this->mapByReference($value);
    511▕                     }
    512▕
  ➜ 513▕                     $property->setValue($data, $value);
    514▕                 }
    515▕             } while ($reflection = $reflection->getParentClass());
    516▕         }
    517▕     }

      +3 vendor frames

  4   [internal]:0
      Laravel\SerializableClosure\Serializers\Native::__serialize()
      +14 vendor frames

  19  artisan:35
      Illuminate\Foundation\Console\Kernel::handle()

```

Note from the traceback that the serialization code which is crashing on us is using some kind of lower level reflection API to set the property value directly (circumventing normal member visibility rules, but not (apparently) typehint/typechecking of the same member... thanks PHP).

This PR allows Laravel's automatic closure serialization to work when running `artisan route:cache` by allowing assignment of the relevant properties to not only be `Closure` but also the `Laravel\SerializableClosure\Contracts\Serializable` interface. Since the serialization code is only doing direct assignment we do not need to update the methods' typehints.

I don't know the full implications of this PR as I have not dug super deep into how closure serialization works. Nevertheless, I _have_ tested that this change fixes running `route:cache` as well as has not broken upload signing for me (whether `multipart` or not).